### PR TITLE
core: Make CTS/Play Integrity pass again

### DIFF
--- a/core/java/com/android/internal/util/crdroid/AttestationHooks.java
+++ b/core/java/com/android/internal/util/crdroid/AttestationHooks.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.util.evolution;
+
+import android.app.Application;
+import android.os.Build;
+import android.os.Build.VERSION;
+import android.os.SystemProperties;
+import android.util.Log;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+/** @hide */
+public final class AttestationHooks {
+    private static final String TAG = "Attestation";
+
+    private static final String PACKAGE_GMS = "com.google.android.gms";
+    private static final String PACKAGE_FINSKY = "com.android.vending";
+    private static final String PROCESS_UNSTABLE = "com.google.android.gms.unstable";
+
+    private static volatile boolean sIsGms = false;
+    private static volatile boolean sIsFinsky = false;
+
+    private AttestationHooks() { }
+
+    private static void setBuildField(String key, String value) {
+        try {
+            // Unlock
+            Field field = Build.class.getDeclaredField(key);
+            field.setAccessible(true);
+
+            // Edit
+            field.set(null, value);
+
+            // Lock
+            field.setAccessible(false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            Log.e(TAG, "Failed to spoof Build." + key, e);
+        }
+    }
+
+    private static void setVersionField(String key, Integer value) {
+        try {
+            // Unlock
+            Field field = Build.VERSION.class.getDeclaredField(key);
+            field.setAccessible(true);
+
+            // Edit
+            field.set(null, value);
+
+            // Lock
+            field.setAccessible(false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            Log.e(TAG, "Failed to spoof Build." + key, e);
+        }
+    }
+
+    private static void spoofBuildGms() {
+        // Alter model name and fingerprint to avoid hardware attestation enforcement
+        setBuildField("FINGERPRINT", "google/marlin/marlin:7.1.2/NJH47F/4146041:user/release-keys");
+        setBuildField("PRODUCT", "marlin");
+        setBuildField("DEVICE", "marlin");
+        setBuildField("MODEL", "Pixel XL");
+        setVersionField("DEVICE_INITIAL_SDK_INT", Build.VERSION_CODES.N_MR1);
+    }
+
+    public static void initApplicationBeforeOnCreate(Application app) {
+        if (PACKAGE_GMS.equals(app.getPackageName()) &&
+                PROCESS_UNSTABLE.equals(Application.getProcessName())) {
+            sIsGms = true;
+            spoofBuildGms();
+        }
+
+        if (PACKAGE_FINSKY.equals(app.getPackageName())) {
+            sIsFinsky = true;
+        }
+    }
+
+    private static boolean isCallerSafetyNet() {
+        return sIsGms && Arrays.stream(Thread.currentThread().getStackTrace())
+                .anyMatch(elem -> elem.getClassName().contains("DroidGuard"));
+    }
+
+    public static void onEngineGetCertificateChain() {
+        // Check stack for SafetyNet or Play Integrity
+        if (isCallerSafetyNet() || sIsFinsky) {
+            Log.i(TAG, "Blocked key attestation sIsGms=" + sIsGms + " sIsFinsky=" + sIsFinsky);
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/core/java/com/android/internal/util/crdroid/PropImitationHooks.java
+++ b/core/java/com/android/internal/util/crdroid/PropImitationHooks.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.util.evolution;
+
+import android.app.Application;
+import android.content.res.Resources;
+import android.os.Build;
+import android.util.Log;
+
+import com.android.internal.R;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+public class PropImitationHooks {
+
+    private static final String TAG = "PropImitationHooks";
+    private static final boolean DEBUG = false;
+
+    private static final String sCertifiedFp =
+            Resources.getSystem().getString(R.string.config_certifiedFingerprint);
+
+    private static final String sStockFp =
+            Resources.getSystem().getString(R.string.config_stockFingerprint);
+
+    private static final String PACKAGE_ARCORE = "com.google.ar.core";
+    private static final String PACKAGE_FINSKY = "com.android.vending";
+    private static final String PACKAGE_GMS = "com.google.android.gms";
+    private static final String PROCESS_GMS_UNSTABLE = PACKAGE_GMS + ".unstable";
+
+    private static volatile boolean sIsGms = false;
+    private static volatile boolean sIsFinsky = false;
+
+    public static void setProps(Application app) {
+        final String packageName = app.getPackageName();
+        final String processName = app.getProcessName();
+
+        if (packageName == null || processName == null) {
+            return;
+        }
+
+        sIsGms = packageName.equals(PACKAGE_GMS) && processName.equals(PROCESS_GMS_UNSTABLE);
+        sIsFinsky = packageName.equals(PACKAGE_FINSKY);
+
+        if (!sCertifiedFp.isEmpty() && (sIsGms || sIsFinsky)) {
+            dlog("Setting certified fingerprint for: " + packageName);
+            setPropValue("FINGERPRINT", sCertifiedFp);
+        } else if (!sStockFp.isEmpty() && packageName.equals(PACKAGE_ARCORE)) {
+            dlog("Setting stock fingerprint for: " + packageName);
+            setPropValue("FINGERPRINT", sStockFp);
+        }
+    }
+
+    private static void setPropValue(String key, Object value){
+        try {
+            dlog("Setting prop " + key + " to " + value.toString());
+            Field field = Build.class.getDeclaredField(key);
+            field.setAccessible(true);
+            field.set(null, value);
+            field.setAccessible(false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            Log.e(TAG, "Failed to set prop " + key, e);
+        }
+    }
+
+    private static boolean isCallerSafetyNet() {
+        return sIsGms && Arrays.stream(Thread.currentThread().getStackTrace())
+                .anyMatch(elem -> elem.getClassName().contains("DroidGuard"));
+    }
+
+    public static void onEngineGetCertificateChain() {
+        // Check stack for SafetyNet or Play Integrity
+        if (isCallerSafetyNet() || sIsFinsky) {
+            dlog("Blocked key attestation sIsGms=" + sIsGms + " sIsFinsky=" + sIsFinsky);
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public static void dlog(String msg) {
+      if (DEBUG) Log.d(TAG, msg);
+    }
+}

--- a/keystore/java/android/security/keystore2/AndroidKeyStoreSpi.java
+++ b/keystore/java/android/security/keystore2/AndroidKeyStoreSpi.java
@@ -21,6 +21,7 @@ import android.hardware.biometrics.BiometricManager;
 import android.hardware.security.keymint.HardwareAuthenticatorType;
 import android.hardware.security.keymint.KeyParameter;
 import android.hardware.security.keymint.SecurityLevel;
+import android.os.SystemProperties;
 import android.security.GateKeeper;
 import android.security.KeyStore2;
 import android.security.KeyStoreParameter;
@@ -77,7 +78,8 @@ import java.util.Set;
 
 import javax.crypto.SecretKey;
 
-import com.android.internal.util.crdroid.PixelPropsUtils;
+import com.android.internal.util.crdroid.AttestationHooks;
+import com.android.internal.util.crdroid.PropImitationHooks;
 
 /**
  * A java.security.KeyStore interface for the Android KeyStore. An instance of
@@ -101,6 +103,8 @@ import com.android.internal.util.crdroid.PixelPropsUtils;
 public class AndroidKeyStoreSpi extends KeyStoreSpi {
     public static final String TAG = "AndroidKeyStoreSpi";
     public static final String NAME = "AndroidKeyStore";
+
+    private static final String DEVICE = "ro.product.device";
 
     private KeyStore2 mKeyStore;
     private @KeyProperties.Namespace int mNamespace = KeyProperties.NAMESPACE_APPLICATION;
@@ -164,9 +168,29 @@ public class AndroidKeyStoreSpi extends KeyStoreSpi {
         }
     }
 
+    // Codenames for currently supported Pixels by Google
+    private static final String[] pixelCodenames = {
+            "cheetah",
+            "panther",
+            "bluejay",
+            "oriole",
+            "raven",
+            "redfin",
+            "barbet",
+            "bramble",
+            "sunfish",
+            "coral",
+            "flame"
+    };
+
     @Override
     public Certificate[] engineGetCertificateChain(String alias) {
-        PixelPropsUtils.onEngineGetCertificateChain();
+        boolean isPixelDevice = Arrays.asList(pixelCodenames).contains(SystemProperties.get(DEVICE));
+        if (!isPixelDevice) {
+            AttestationHooks.onEngineGetCertificateChain();
+        } else {
+            PropImitationHooks.onEngineGetCertificateChain();
+        }
 
         KeyEntryResponse response = getKeyMetadata(alias);
 


### PR DESCRIPTION
The logic behind CTS and Play Integrity has been updated today it now checks the product and model names against the fingerprint and if they do not match the CTS profile will fail.

Also while we are at it use a newer FP from Pixel XL and add logging for key attestation blocking for debugging.

Test: Boot, check for CTS and Play Integrity

[Stallix - Evolution X]
Switch back to using the AttestationHooks impl for Play Integrity spoofing checks. Use with PropImitationHooks changes from StatiXOS for Pixel device compatibility.

Change-Id: I089d5ef935bba40338e10c795ea7d181103ffd15
Signed-off-by: Dyneteve <dyneteve@hentaios.com>
Co-authored-by: Stallix <joey@evolution-x.org>